### PR TITLE
chore: Add AI tools

### DIFF
--- a/home/ceramiq/programs.nix
+++ b/home/ceramiq/programs.nix
@@ -6,5 +6,6 @@
     openshift
     terraform-docs
     tflint
+    opencode
   ];
 }

--- a/home/ceramiq/vscode.nix
+++ b/home/ceramiq/vscode.nix
@@ -120,6 +120,12 @@
         workbench.preferredLightColorTheme = "Catppuccin Latte";
         "workbench.iconTheme" = "catppuccin-mocha";
         github.copilot = {
+          enable = {
+            "*" = true;
+            "plaintext" = false;
+            "markdown" = true;
+            "scminput" = false;
+          };
           nextEditSuggestions.enabled = true;
           advanced = {
             # Enable GitHub Copilot

--- a/hosts/ceramiq/homebrew.nix
+++ b/hosts/ceramiq/homebrew.nix
@@ -22,6 +22,7 @@ _: {
         args = { "no_quarantine" = true; };
       }
       "iterm2"
+      "ghostty"
     ];
 
     brews = [


### PR DESCRIPTION
This pull request introduces several updates to your development environment configuration, focusing on adding new tools and enhancing GitHub Copilot settings in VSCode. The main changes are grouped below by theme.

**Tooling additions:**
* Added `opencode` to the list of programs in `programs.nix`, making it available for installation and use.
* Included `ghostty` in the list of casks in `homebrew.nix`, enabling installation of this terminal emulator.

**VSCode configuration improvements:**
* Updated the GitHub Copilot extension settings in `vscode.nix` to allow more granular control over where Copilot is enabled (e.g., enabled for all languages by default, but disabled for plaintext and scminput, and enabled for markdown).