### PR TITLE
chore: Upgrade dependencies and change deprecated swww to awww

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Check <https://github.com/nix-community/nixpkgs-xr>
 
 hyprland
 waybar
-swww
+awww
 nixos
 etc...
 

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1774640993,
-        "narHash": "sha256-jIRb6sHAdGvq1zxjZ6Wtv8yrKJ9KcM550R3WcSWD9sc=",
+        "lastModified": 1775117962,
+        "narHash": "sha256-bjhAkoBTk/xKkJtlTD5EdErzVwkBi+aLzdGcv339SzQ=",
         "owner": "amber-lang",
         "repo": "Amber",
-        "rev": "ddf82bbc57ee2f87a1e73df123e7397bf7b5df2e",
+        "rev": "372b34928cec88bcb22f1ffbcc77fa9c7ece2f59",
         "type": "github"
       },
       "original": {
@@ -54,16 +54,36 @@
         "type": "github"
       }
     },
-    "catppuccin": {
+    "awww": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2"
+        "flake-compat": "flake-compat",
+        "nixpkgs": "nixpkgs_2",
+        "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1774616169,
-        "narHash": "sha256-fP4bU3SOH5sefSl6EagqULFs+bXoo3h3VLQCCyJplo4=",
+        "lastModified": 1774191766,
+        "narHash": "sha256-bvO+gfuUOVUiBEwAJ5A2RjpysPzCfyXD+DM8piOa1+4=",
+        "ref": "refs/heads/main",
+        "rev": "7a8fc2e646b97e5ae508a44d3449e3b41345d456",
+        "revCount": 1336,
+        "type": "git",
+        "url": "https://codeberg.org/LGFae/awww"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://codeberg.org/LGFae/awww"
+      }
+    },
+    "catppuccin": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1775213373,
+        "narHash": "sha256-wJHsijC2l/E+ovmlpPGha8pXA6RHSwHWmBV97gvkmyI=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "e616c61cd9f7b05b32af266bc005fa266860dacf",
+        "rev": "ba73719e673e7c2d89ac2f8df0bc0d48983e4907",
         "type": "github"
       },
       "original": {
@@ -75,7 +95,7 @@
     "cl-nix-lite": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs_6",
+        "nixpkgs": "nixpkgs_7",
         "systems": "systems_3",
         "treefmt-nix": "treefmt-nix"
       },
@@ -117,6 +137,22 @@
     "flake-compat": {
       "flake": false,
       "locked": {
+        "lastModified": 1761588595,
+        "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
         "lastModified": 1767039857,
         "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
         "owner": "NixOS",
@@ -130,7 +166,7 @@
         "type": "github"
       }
     },
-    "flake-compat_2": {
+    "flake-compat_3": {
       "flake": false,
       "locked": {
         "lastModified": 1730663653,
@@ -147,7 +183,7 @@
         "type": "github"
       }
     },
-    "flake-compat_3": {
+    "flake-compat_4": {
       "flake": false,
       "locked": {
         "lastModified": 1767039857,
@@ -163,7 +199,7 @@
         "type": "github"
       }
     },
-    "flake-compat_4": {
+    "flake-compat_5": {
       "locked": {
         "lastModified": 1733328505,
         "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
@@ -177,7 +213,7 @@
         "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
       }
     },
-    "flake-compat_5": {
+    "flake-compat_6": {
       "flake": false,
       "locked": {
         "lastModified": 1696426674,
@@ -234,11 +270,11 @@
         "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
-        "lastModified": 1769996383,
-        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
         "type": "github"
       },
       "original": {
@@ -290,7 +326,7 @@
     },
     "git-hooks": {
       "inputs": {
-        "flake-compat": "flake-compat_3",
+        "flake-compat": "flake-compat_4",
         "gitignore": "gitignore_2",
         "nixpkgs": [
           "nix-gaming",
@@ -362,11 +398,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774647770,
-        "narHash": "sha256-UNNi14XiqRWWjO8ykbFwA5wRwx7EscsC+GItOVpuGjc=",
+        "lastModified": 1775247674,
+        "narHash": "sha256-MCaiC3iWarAsmu8KJXgJHb1H8lf+BD9gymvxkbmNVdc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "02371c05a04a2876cf92e2d67a259e8f87399068",
+        "rev": "03bdcf84f092956943dcf9ef164481e463512716",
         "type": "github"
       },
       "original": {
@@ -465,17 +501,17 @@
         "hyprutils": "hyprutils",
         "hyprwayland-scanner": "hyprwayland-scanner",
         "hyprwire": "hyprwire",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_4",
         "pre-commit-hooks": "pre-commit-hooks",
         "systems": "systems_2",
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1774635054,
-        "narHash": "sha256-NVjEJ5u0VHKTc/A17kWDfXgFnBAsP2BOMNj+fAv58mM=",
+        "lastModified": 1775165818,
+        "narHash": "sha256-Bkb1ha9bB8IiWIBW2Z6shj2Erqx08VH1I9ljYl8zxGU=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "5dfb1033a433789021ab9f94b9044e6f32496211",
+        "rev": "f25473b21b45ab8ded4a0dbba69eb6b6660d568e",
         "type": "github"
       },
       "original": {
@@ -718,7 +754,7 @@
     "impermanence": {
       "inputs": {
         "home-manager": "home-manager_2",
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
         "lastModified": 1769548169,
@@ -736,8 +772,8 @@
     },
     "lan-mouse": {
       "inputs": {
-        "nixpkgs": "nixpkgs_5",
-        "rust-overlay": "rust-overlay_2"
+        "nixpkgs": "nixpkgs_6",
+        "rust-overlay": "rust-overlay_3"
       },
       "locked": {
         "lastModified": 1774442217,
@@ -756,9 +792,9 @@
     "mac-app-util": {
       "inputs": {
         "cl-nix-lite": "cl-nix-lite",
-        "flake-compat": "flake-compat_2",
+        "flake-compat": "flake-compat_3",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs_8",
+        "nixpkgs": "nixpkgs_9",
         "systems": "systems_4",
         "treefmt-nix": "treefmt-nix_2"
       },
@@ -805,11 +841,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773000227,
-        "narHash": "sha256-zm3ftUQw0MPumYi91HovoGhgyZBlM4o3Zy0LhPNwzXE=",
+        "lastModified": 1775037210,
+        "narHash": "sha256-KM2WYj6EA7M/FVZVCl3rqWY+TFV5QzSyyGE2gQxeODU=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "da529ac9e46f25ed5616fd634079a5f3c579135f",
+        "rev": "06648f4902343228ce2de79f291dd5a58ee12146",
         "type": "github"
       },
       "original": {
@@ -823,14 +859,14 @@
       "inputs": {
         "flake-parts": "flake-parts_2",
         "git-hooks": "git-hooks",
-        "nixpkgs": "nixpkgs_10"
+        "nixpkgs": "nixpkgs_11"
       },
       "locked": {
-        "lastModified": 1774579928,
-        "narHash": "sha256-HgDoK1Z1koMnEf1aX2FK02xwHmKsOmVR6dGhJOFZA9Y=",
+        "lastModified": 1775098068,
+        "narHash": "sha256-9L2LEBXJYhYeO+cx8rYAFdWMEApM0bLQykgoCgL6Ssg=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "34f157cab59fc5fec17f7cef7a0f563d303b3fc9",
+        "rev": "4d81dcca59d7a6bfe01f3ad764e0c7890836e255",
         "type": "github"
       },
       "original": {
@@ -841,14 +877,14 @@
     },
     "nix-vscode-extensions": {
       "inputs": {
-        "nixpkgs": "nixpkgs_11"
+        "nixpkgs": "nixpkgs_12"
       },
       "locked": {
-        "lastModified": 1774580365,
-        "narHash": "sha256-IsFhvJ0GC42GGP8ldTGNU5bdxz42JPQANPgeRD8Igxk=",
+        "lastModified": 1775185075,
+        "narHash": "sha256-fUvn9pAPPplNzpT27n51wBKBEJtHFLb8b2b+5fAU1Eo=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "68f00afe80f7c424fb311d698d7c6b64cdd27572",
+        "rev": "b557a6397204dd4e148144979c99e1e66e8ab2e8",
         "type": "github"
       },
       "original": {
@@ -859,11 +895,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1774567711,
-        "narHash": "sha256-uVlOHBvt6Vc/iYNJXLPa4c3cLXwMllOCVfAaLAcphIo=",
+        "lastModified": 1775203647,
+        "narHash": "sha256-6MWaMLXK9QMndI94CIxeiPafi3wuO+imCtK9tfhsZdw=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "3f6f874dfc34d386d10e434c48ad966c4832243e",
+        "rev": "80afbd13eea0b7c4ac188de949e1711b31c2b5f0",
         "type": "github"
       },
       "original": {
@@ -921,11 +957,11 @@
     },
     "nixpkgs-lib_3": {
       "locked": {
-        "lastModified": 1769909678,
-        "narHash": "sha256-cBEymOf4/o3FD5AZnzC3J9hLbiZ+QDT/KDuyHXVJOpM=",
+        "lastModified": 1772328832,
+        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "72716169fe93074c333e8d0173151350670b824c",
+        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
         "type": "github"
       },
       "original": {
@@ -936,19 +972,19 @@
     },
     "nixpkgs-xr": {
       "inputs": {
-        "flake-compat": "flake-compat_4",
+        "flake-compat": "flake-compat_5",
         "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_13",
+        "nixpkgs": "nixpkgs_14",
         "nvfetcher": "nvfetcher",
         "systems": "systems_5",
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1774650911,
-        "narHash": "sha256-q+PtgDBO4lmjmNTJ+2e/aIu2lga4xLYN21sjnBk7pjw=",
+        "lastModified": 1775182622,
+        "narHash": "sha256-8gRQXTIhspvFsNPJo6o09OBrtfKqdoOcBNGa5J7rG40=",
         "owner": "nix-community",
         "repo": "nixpkgs-xr",
-        "rev": "d28be2ee4a9615ba974e4b73d6d50d421ed427aa",
+        "rev": "bf08f400e1979b2af5383ccc5c6e80d3feac00c3",
         "type": "github"
       },
       "original": {
@@ -959,11 +995,27 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1773840656,
-        "narHash": "sha256-9tpvMGFteZnd3gRQZFlRCohVpqooygFuy9yjuyRL2C0=",
+        "lastModified": 1761236834,
+        "narHash": "sha256-+pthv6hrL5VLW2UqPdISGuLiUZ6SnAXdd2DdUE+fV2Q=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d5faa84122bc0a1fd5d378492efce4e289f8eac1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_11": {
+      "locked": {
+        "lastModified": 1774610258,
+        "narHash": "sha256-HaThtroVD9wRdx7KQk0B75JmFcXlMUoEdDFNOMOlsOs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9cf7092bdd603554bd8b63c216e8943cf9b12512",
+        "rev": "832efc09b4caf6b4569fbf9dc01bec3082a00611",
         "type": "github"
       },
       "original": {
@@ -973,7 +1025,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_11": {
+    "nixpkgs_12": {
       "locked": {
         "lastModified": 1766025857,
         "narHash": "sha256-Lav5jJazCW4mdg1iHcROpuXqmM94BWJvabLFWaJVJp0=",
@@ -989,39 +1041,39 @@
         "type": "github"
       }
     },
-    "nixpkgs_12": {
-      "locked": {
-        "lastModified": 1774386573,
-        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_13": {
       "locked": {
-        "lastModified": 1774386573,
-        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
-        "owner": "NixOS",
+        "lastModified": 1775036866,
+        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
+        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
+        "owner": "nixos",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_14": {
+      "locked": {
+        "lastModified": 1775036866,
+        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_15": {
       "locked": {
         "lastModified": 1719082008,
         "narHash": "sha256-jHJSUH619zBQ6WdC21fFAlDxHErKVDJ5fpN0Hgx4sjs=",
@@ -1037,13 +1089,13 @@
         "type": "github"
       }
     },
-    "nixpkgs_15": {
+    "nixpkgs_16": {
       "locked": {
-        "lastModified": 1771848320,
-        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
+        "lastModified": 1774386573,
+        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
+        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
         "type": "github"
       },
       "original": {
@@ -1055,11 +1107,27 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1773821835,
-        "narHash": "sha256-TJ3lSQtW0E2JrznGVm8hOQGVpXjJyXY2guAxku2O9A4=",
+        "lastModified": 1763934636,
+        "narHash": "sha256-9glbI7f1uU+yzQCq5LwLgdZqx6svOhZWkd4JRY265fc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "ee09932cedcef15aaf476f9343d1dea2cb77e261",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1775036866,
+        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b40629efe5d6ec48dd1efba650c797ddbd39ace0",
+        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
         "type": "github"
       },
       "original": {
@@ -1069,7 +1137,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1774106199,
         "narHash": "sha256-US5Tda2sKmjrg2lNHQL3jRQ6p96cgfWh3J1QBliQ8Ws=",
@@ -1085,7 +1153,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1768564909,
         "narHash": "sha256-Kell/SpJYVkHWMvnhqJz/8DqQg2b6PguxVWOuadbHCc=",
@@ -1101,7 +1169,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1772963539,
         "narHash": "sha256-9jVDGZnvCckTGdYT53d/EfznygLskyLQXYwJLKMPsZs=",
@@ -1117,7 +1185,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_7": {
       "locked": {
         "lastModified": 1766736597,
         "narHash": "sha256-BASnpCLodmgiVn0M1MU2Pqyoz0aHwar/0qLkp7CjvSQ=",
@@ -1133,7 +1201,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_7": {
+    "nixpkgs_8": {
       "locked": {
         "lastModified": 1761236834,
         "narHash": "sha256-+pthv6hrL5VLW2UqPdISGuLiUZ6SnAXdd2DdUE+fV2Q=",
@@ -1149,7 +1217,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_8": {
+    "nixpkgs_9": {
       "locked": {
         "lastModified": 1732617236,
         "narHash": "sha256-PYkz6U0bSEaEB1al7O1XsqVNeSNS+s3NVclJw7YC43w=",
@@ -1162,22 +1230,6 @@
         "owner": "NixOS",
         "repo": "nixpkgs",
         "rev": "af51545ec9a44eadf3fe3547610a5cdd882bc34e",
-        "type": "github"
-      }
-    },
-    "nixpkgs_9": {
-      "locked": {
-        "lastModified": 1761236834,
-        "narHash": "sha256-+pthv6hrL5VLW2UqPdISGuLiUZ6SnAXdd2DdUE+fV2Q=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "d5faa84122bc0a1fd5d378492efce4e289f8eac1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
         "type": "github"
       }
     },
@@ -1213,7 +1265,7 @@
     },
     "pre-commit-hooks": {
       "inputs": {
-        "flake-compat": "flake-compat",
+        "flake-compat": "flake-compat_2",
         "gitignore": "gitignore",
         "nixpkgs": [
           "hyprland",
@@ -1236,17 +1288,17 @@
     },
     "pyprland": {
       "inputs": {
-        "flake-compat": "flake-compat_5",
-        "nixpkgs": "nixpkgs_14",
+        "flake-compat": "flake-compat_6",
+        "nixpkgs": "nixpkgs_15",
         "pyproject-nix": "pyproject-nix",
         "systems": "systems_6"
       },
       "locked": {
-        "lastModified": 1774652566,
-        "narHash": "sha256-v/US22AOZ9yp+P9bj5M0E+nSbl9Iru9lGqLDSBn6LTE=",
+        "lastModified": 1775237005,
+        "narHash": "sha256-zP2hmsV+qXhZ0UgX4ysSuH9Br2OhMlPW5vM1+6IkRB0=",
         "owner": "hyprland-community",
         "repo": "pyprland",
-        "rev": "c81b1590173443a34efa0b1a7b242a4e9051d0d5",
+        "rev": "8b0909cbd76fc8095bb5a76fe67c6f0e5a66277c",
         "type": "github"
       },
       "original": {
@@ -1279,6 +1331,7 @@
     "root": {
       "inputs": {
         "amber": "amber",
+        "awww": "awww",
         "catppuccin": "catppuccin",
         "disko": "disko",
         "home-manager": "home-manager",
@@ -1290,7 +1343,7 @@
         "nix-gaming": "nix-gaming",
         "nix-vscode-extensions": "nix-vscode-extensions",
         "nixos-hardware": "nixos-hardware",
-        "nixpkgs": "nixpkgs_12",
+        "nixpkgs": "nixpkgs_13",
         "nixpkgs-xr": "nixpkgs-xr",
         "pyprland": "pyprland",
         "sops-nix": "sops-nix",
@@ -1321,6 +1374,27 @@
     "rust-overlay_2": {
       "inputs": {
         "nixpkgs": [
+          "awww",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1764038373,
+        "narHash": "sha256-M6w2wNBRelcavoDAyFL2iO4NeWknD40ASkH1S3C0YGM=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "ab3536fe850211a96673c6ffb2cb88aab8071cc9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_3": {
+      "inputs": {
+        "nixpkgs": [
           "lan-mouse",
           "nixpkgs"
         ]
@@ -1346,11 +1420,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774303811,
-        "narHash": "sha256-fhG4JAcLgjKwt+XHbjs8brpWnyKUfU4LikLm3s0Q/ic=",
+        "lastModified": 1775188331,
+        "narHash": "sha256-/0BoSi0Dg0ON7IW0oscM12WSPBaMSCn36XTt0lHZoy8=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "614e256310e0a4f8a9ccae3fa80c11844fba7042",
+        "rev": "8f093d0d2f08f37317778bd94db5951d6cce6c46",
         "type": "github"
       },
       "original": {
@@ -1452,14 +1526,14 @@
     "talhelper": {
       "inputs": {
         "flake-parts": "flake-parts_3",
-        "nixpkgs": "nixpkgs_15"
+        "nixpkgs": "nixpkgs_16"
       },
       "locked": {
-        "lastModified": 1774578238,
-        "narHash": "sha256-eBg+3ed0brYujIXZWKw/MsM79pcxXef8pTzkR3eCaxc=",
+        "lastModified": 1775197310,
+        "narHash": "sha256-gKxAIkbZWFMj9o++YWfzr2brnpe7K5tAiDy0hxw4DSI=",
         "owner": "budimanjojo",
         "repo": "talhelper",
-        "rev": "aea4a20c1fbf1a7fae7f809d2d456bdc835f9093",
+        "rev": "e6523cb86d3352b985de118251ea097aa10f619a",
         "type": "github"
       },
       "original": {
@@ -1470,7 +1544,7 @@
     },
     "treefmt-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_7"
+        "nixpkgs": "nixpkgs_8"
       },
       "locked": {
         "lastModified": 1766000401,
@@ -1488,7 +1562,7 @@
     },
     "treefmt-nix_2": {
       "inputs": {
-        "nixpkgs": "nixpkgs_9"
+        "nixpkgs": "nixpkgs_10"
       },
       "locked": {
         "lastModified": 1766000401,
@@ -1512,11 +1586,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773297127,
-        "narHash": "sha256-6E/yhXP7Oy/NbXtf1ktzmU8SdVqJQ09HC/48ebEGBpk=",
+        "lastModified": 1775125835,
+        "narHash": "sha256-2qYcPgzFhnQWchHo0SlqLHrXpux5i6ay6UHA+v2iH4U=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "71b125cd05fbfd78cab3e070b73544abe24c5016",
+        "rev": "75925962939880974e3ab417879daffcba36c4a3",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -92,6 +92,9 @@
 
     # https://github.com/hraban/mac-app-util
     mac-app-util.url = "github:hraban/mac-app-util";
+
+    # https://codeberg.org/LGFae/awww
+    awww.url = "git+https://codeberg.org/LGFae/awww";
   };
 
   outputs = inputs@{

--- a/home/common/gnu-linux/hyprland/awww.nix
+++ b/home/common/gnu-linux/hyprland/awww.nix
@@ -1,9 +1,9 @@
 { pkgs, ... }: {
   home.file = {
-    swww_randomize = {
+    awww_randomize = {
       enable = true;
       executable = true;
-      target = "./.config/swww/swww_randomize.sh";
+      target = "./.config/awww/awww_randomize.sh";
       text = ''
         #!/usr/bin/env sh
         # Changes the wallpaper to a randomly chosen image in a given directory
@@ -17,10 +17,10 @@
           exit 1
         fi
 
-        # See swww-img(1)
+        # See awww-img(1)
         RESIZE_TYPE="crop"
-        export SWWW_TRANSITION_FPS="''${SWWW_TRANSITION_FPS:-60}"
-        export SWWW_TRANSITION_STEP="''${SWWW_TRANSITION_STEP:-2}"
+        export AWWW_TRANSITION_FPS="''${AWWW_TRANSITION_FPS:-60}"
+        export AWWW_TRANSITION_STEP="''${AWWW_TRANSITION_STEP:-2}"
 
         while true; do
           find -L "$1" -type f \
@@ -29,17 +29,17 @@
           done \
           | sort -n | cut -d':' -f2- \
           | while read -r img; do
-            swww img --transition-type any --resize="$RESIZE_TYPE" "$img"
+            awww img --transition-type any --resize="$RESIZE_TYPE" "$img"
             sleep "''${2:-$DEFAULT_INTERVAL}"
           done
         done
       '';
     };
 
-    swww_daynnight = {
+    awww_daynnight = {
       enable = true;
       executable = true;
-      target = "./.config/swww/swww_daynnight.sh";
+      target = "./.config/awww/awww_daynnight.sh";
       text = ''
         #!/usr/bin/env bash
         # Change the wallpaper to a randomly chosen image in a given directories
@@ -53,10 +53,10 @@
           exit 1
         fi
 
-        # See swww-img(1)
+        # See awww-img(1)
         RESIZE_TYPE="crop"
-        export SWWW_TRANSITION_FPS="''${SWWW_TRANSITION_FPS:-60}"
-        export SWWW_TRANSITION_STEP="''${SWWW_TRANSITION_STEP:-2}"
+        export AWWW_TRANSITION_FPS="''${AWWW_TRANSITION_FPS:-60}"
+        export AWWW_TRANSITION_STEP="''${AWWW_TRANSITION_STEP:-2}"
 
         while true; do
           __current_time=$(date +%H:%M)
@@ -72,7 +72,7 @@
           done \
           | sort -n | cut -d':' -f2- \
           | while read -r img; do
-            swww img --transition-type any --resize="$RESIZE_TYPE" "$img"
+            awww img --transition-type any --resize="$RESIZE_TYPE" "$img"
             sleep "''${3:-$DEFAULT_INTERVAL}"
           done
         done
@@ -88,7 +88,7 @@
         rev = "4f3ada0efcd1e485bb9ebab8fb3612547bba1d5e";
         sha256 = "sha256-lrWGTDk5OfkMXttiCQKFnY7Sz5nUkz1G6gQCOjM0WI0=";
       };
-      target = "./.config/swww/wallpapers";
+      target = "./.config/awww/wallpapers";
     };
   };
 }

--- a/home/common/gnu-linux/hyprland/default.nix
+++ b/home/common/gnu-linux/hyprland/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, username, ... }: {
+{ pkgs, username, inputs, ... }: {
   imports = [
     ./avizo.nix
     ./config.nix
@@ -7,7 +7,7 @@
     ./hyprland.nix
     ./hyprlock.nix
     ./rofi.nix
-    ./swww.nix
+    ./awww.nix
     ./waybar.nix
     ./wlogout.nix
   ];
@@ -101,12 +101,12 @@
     hyprgraphics
     hyprland-qtutils
     imagemagick
+    inputs.awww.packages.${pkgs.stdenv.hostPlatform.system}.awww
     # inputs.pyprland.packages."x86_64-linux".pyprland # https://hyprland-community.github.io/pyprland/
     kdePackages.qtwayland # qt6-wayland
     libsForQt5.qt5.qtwayland # qt5-wayland
     slurp
     swappy
-    swww
     wl-clipboard
   ];
 }

--- a/home/common/gnu-linux/hyprland/hyprland.nix
+++ b/home/common/gnu-linux/hyprland/hyprland.nix
@@ -13,7 +13,7 @@ _: {
       };
 
       exec-once = [
-        "swww query || swww-daemon & $HOME/.config/swww/swww_randomize.sh $HOME/.config/swww/wallpapers/wallpapers 60"
+        "awww query || awww-daemon & $HOME/.config/awww/awww_randomize.sh $HOME/.config/awww/wallpapers/wallpapers 60"
         "systemctl --user start hyprpolkitagent"
         "wl-paste --type text --watch cliphist store" # Stores only text data
         "wl-paste --type image --watch cliphist store" # Stores only image data


### PR DESCRIPTION
This pull request migrates the Hyprland wallpaper management setup from `swww` to `awww`. It updates all relevant configuration, scripts, and dependencies to use `awww` instead of `swww`, ensuring a consistent transition across the codebase.

**Migration from `swww` to `awww`:**

* Replaced all references to `swww` with `awww` in the Hyprland configuration, including the main import in `default.nix`, and updated the package list to include `awww` from the new input source. (`[[1]](diffhunk://#diff-0018866b64ab6f3c58ede44f56541968a07e7bd5ae27a97be9a805bb081c5989L10-R10)`, `[[2]](diffhunk://#diff-0018866b64ab6f3c58ede44f56541968a07e7bd5ae27a97be9a805bb081c5989R104-L109)`, `[[3]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R95-R97)`)
* Renamed the wallpaper management Nix module from `swww.nix` to `awww.nix`, and updated script names, file paths, and environment variables accordingly. (`[[1]](diffhunk://#diff-4e7c9a05c08a523bec34a65267ed867425515a24b9ab05232a31b4e5429869fdL3-R6)`, `[[2]](diffhunk://#diff-4e7c9a05c08a523bec34a65267ed867425515a24b9ab05232a31b4e5429869fdL20-R23)`, `[[3]](diffhunk://#diff-4e7c9a05c08a523bec34a65267ed867425515a24b9ab05232a31b4e5429869fdL32-R42)`, `[[4]](diffhunk://#diff-4e7c9a05c08a523bec34a65267ed867425515a24b9ab05232a31b4e5429869fdL56-R59)`, `[[5]](diffhunk://#diff-4e7c9a05c08a523bec34a65267ed867425515a24b9ab05232a31b4e5429869fdL75-R75)`, `[[6]](diffhunk://#diff-4e7c9a05c08a523bec34a65267ed867425515a24b9ab05232a31b4e5429869fdL91-R91)`)
* Updated the Hyprland launch command to use `awww` for wallpaper randomization on startup. (`[home/common/gnu-linux/hyprland/hyprland.nixL16-R16](diffhunk://#diff-3e33aeee725196a40b2883dd168192e7b734a128e1cdd2413cd6fc560288e2a9L16-R16)`)

**Documentation and metadata updates:**

* Changed the `README.md` to list `awww` instead of `swww` as a dependency. (`[README.mdL68-R68](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L68-R68)`)

**Other minor changes:**

* Added `inputs` to the argument list in `hyprland/default.nix` to support the new input source for `awww`. (`[home/common/gnu-linux/hyprland/default.nixL1-R1](diffhunk://#diff-0018866b64ab6f3c58ede44f56541968a07e7bd5ae27a97be9a805bb081c5989L1-R1)`)

This change ensures that all wallpaper management functionality now uses `awww`, improving maintainability and consistency.