### PR TITLE
chore: Upgrade Monolith

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,13 +10,13 @@
       "https://cache.nixos.org"
       "https://nix-community.cachix.org"
       "https://hyprland.cachix.org"
-      # "https://nix-gaming.cachix.org"
+      "https://nix-gaming.cachix.org"
     ];
     extra-trusted-public-keys = [
       "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
       "hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc="
-      # "nix-gaming.cachix.org-1:nbjlureqMbRAxR1gJ/f3hxemL9svXaZF/Ees8vCUUs4="
+      "nix-gaming.cachix.org-1:nbjlureqMbRAxR1gJ/f3hxemL9svXaZF/Ees8vCUUs4="
     ];
   };
 
@@ -110,10 +110,13 @@
     sops-nix,
     nix-darwin,
     impermanence,
+    nix-gaming,
     nixpkgs-xr,
     amber,
     nix-vscode-extensions,
+    lan-mouse,
     mac-app-util,
+    awww,
     ...
   }:
   let

--- a/hosts/monolith/games.nix
+++ b/hosts/monolith/games.nix
@@ -57,10 +57,7 @@
     enable = true;
     openFirewall = true;
 
-    # Write information to /etc/xdg/openxr/1/active_runtime.json, VR applications
-    # will automatically read this and work with WiVRn (Note: This does not currently
-    # apply for games run in Valve's Proton)
-    defaultRuntime = true;
+    steam.enable = true;
 
     # Run WiVRn as a systemd service on startup
     autoStart = true;


### PR DESCRIPTION
This pull request primarily updates the Nix flake configuration to re-enable and integrate the `nix-gaming` cache and package, and makes a configuration change for game-related services on the `monolith` host. These changes improve caching efficiency for gaming-related packages and adjust the system setup for gaming and VR support.

**Nix flake improvements:**

* Re-enabled the `nix-gaming` binary cache and its trusted public key in the `flake.nix` configuration, which will speed up builds and downloads for gaming-related packages.
* Added `nix-gaming`, `lan-mouse`, and `awww` as inputs to the flake, making these packages available for use in the configuration.

**Host configuration changes:**

* On the `monolith` host, enabled Steam integration for VR/gaming by setting `steam.enable = true;` in the games configuration, replacing the previous `defaultRuntime` setting for VR.