### PR TITLE
chore: Upgrade Monolith and disable temporary issue

### DIFF
--- a/home/monolith/games.nix
+++ b/home/monolith/games.nix
@@ -13,17 +13,17 @@
   };
 
   # https://nixos.wiki/wiki/Lutris
-  programs.lutris = {
-    enable = true;
-    extraPackages = with pkgs; [
-      mangohud
-      winetricks
-      gamescope
-      gamemode
-      umu-launcher
-    ];
-    protonPackages = [ pkgs.proton-ge-bin ];
-  };
+  # programs.lutris = {
+  #   enable = true;
+  #   extraPackages = with pkgs; [
+  #     mangohud
+  #     winetricks
+  #     gamescope
+  #     gamemode
+  #     umu-launcher
+  #   ];
+  #   protonPackages = [ pkgs.proton-ge-bin ];
+  # };
 
   # VR headset support
   xdg.portal = {

--- a/hosts/monolith/games.nix
+++ b/hosts/monolith/games.nix
@@ -29,7 +29,7 @@
   environment.systemPackages = with pkgs; [
     # https://nixos.wiki/wiki/Android
     android-tools
-    bottles
+    # bottles
     (heroic.override {
       extraPkgs = pkgs: [
         pkgs.gamescope


### PR DESCRIPTION
This pull request comments out the configuration for Lutris and disables the installation of Bottles in the NixOS configuration for the Monolith host. These changes appear to be related to managing which gaming tools are enabled on the system.

Configuration changes for gaming tools:

* Commented out the `programs.lutris` configuration block in `home/monolith/games.nix`, effectively disabling Lutris and its associated extra packages and Proton GE support.
* Removed `bottles` from the system packages in `hosts/monolith/games.nix` by commenting it out, so it will no longer be installed by default.