### PR TITLE
feat: hyprland: switch conf to lua

### DIFF
--- a/home/bubule/hyprland/hyprland.nix
+++ b/home/bubule/hyprland/hyprland.nix
@@ -1,3 +1,15 @@
 _: {
-  wayland.windowManager.hyprland.settings.monitor = [",1920x1200@165.00Hz,auto,1"];
+  wayland.windowManager.hyprland.extraLuaFiles = {
+    "monitors" = {
+      content = ''
+        hl.monitor({
+          output = "eDP-1",
+          mode = "1920x1200@165.00Hz",
+          position = "auto",
+          scale = "1",
+        })
+      '';
+      autoLoad = true;
+    };
+  };
 }

--- a/home/common/gnu-linux/hyprland/default.nix
+++ b/home/common/gnu-linux/hyprland/default.nix
@@ -59,6 +59,7 @@
     # https://github.com/catppuccin/cursors?tab=readme-ov-file
     # https://wiki.hyprland.org/Hypr-Ecosystem/hyprcursor/
     pointerCursor = {
+      enable = true;
       gtk.enable = true;
       name = "catppuccin-mocha-mauve-cursors";
       package = pkgs.catppuccin-cursors.mochaMauve;
@@ -103,8 +104,8 @@
     imagemagick
     inputs.awww.packages.${pkgs.stdenv.hostPlatform.system}.awww
     # inputs.pyprland.packages."x86_64-linux".pyprland # https://hyprland-community.github.io/pyprland/
-    kdePackages.qtwayland # qt6-wayland
-    libsForQt5.qt5.qtwayland # qt5-wayland
+    qt6.qtwayland # qt6-wayland
+    qt5.qtwayland # qt5-wayland
     slurp
     swappy
     wl-clipboard

--- a/home/common/gnu-linux/hyprland/hyprland.nix
+++ b/home/common/gnu-linux/hyprland/hyprland.nix
@@ -1,161 +1,145 @@
-_: {
+{ lib, ... }: {
   wayland.windowManager.hyprland = {
+    configType = "lua";
     enable = true; # enable Hyprland
     systemd = {
       enable = true;
       enableXdgAutostart = true;
     };
     xwayland.enable = true;
-    settings = {
-      ecosystem = {
-        no_update_news = true;
-        no_donation_nag = true;
-      };
-
-      exec-once = [
-        "awww query || awww-daemon & $HOME/.config/awww/awww_randomize.sh $HOME/.config/awww/wallpapers/wallpapers 60"
-        "systemctl --user start hyprpolkitagent"
-        "wl-paste --type text --watch cliphist store" # Stores only text data
-        "wl-paste --type image --watch cliphist store" # Stores only image data
-        "gammastep-indicator"
-      ];
-
-      general = {
-        gaps_in = 1;
-        gaps_out = 5;
-        "col.inactive_border" = "$base";
-        "col.active_border" = "$text";
-        resize_on_border = true;
-        extend_border_grab_area = 15;
-        hover_icon_on_border = true;
-        allow_tearing = true;
-        resize_corner = 3;
-      };
-
-      decoration = {
-        rounding = 10;
-        blur = {
-          enabled = false;
-        };
-        shadow = {
-          enabled = false;
-        };
-      };
-
-      animations = {
-        animation = [
-          "windows, 1, 5, default, popin 50%"
-          "workspaces, 1, 1, default, fade"
-        ];
-      };
-
-      input = {
-        kb_layout = "us";
-        numlock_by_default = false;
-
-        touchpad = {
-          disable_while_typing = true;
-          tap-to-click = true;
-          tap-and-drag = true;
-        };
-      };
-
-      gesture = [
-        "3, horizontal, workspace"
-      ];
-
-      misc = {
-        disable_hyprland_logo = true;
-        disable_splash_rendering = true;
-        background_color = "$accent";
-      };
-
-      cursor = {
-        inactive_timeout = 5;
-        hide_on_key_press = true;
-      };
-
-      "$mod" = "SUPER";
-
-      bind = [
-        # Switch workspaces with mod + [0-9] for the internal monitor
-        "$mod, 1, workspace, 1"
-        "$mod, 2, workspace, 2"
-        "$mod, 3, workspace, 3"
-        "$mod, 4, workspace, 4"
-        "$mod, 5, workspace, 5"
-        "$mod, 6, workspace, 6"
-        "$mod, 7, workspace, 7"
-        "$mod, 8, workspace, 8"
-        "$mod, 9, workspace, 9"
-        "$mod, 0, workspace, 10"
-
-        # Move active window to a workspace with mainMod + SHIFT + [0-9] for the internal monitor
-        "$mod SHIFT, 1, movetoworkspace, 1"
-        "$mod SHIFT, 2, movetoworkspace, 2"
-        "$mod SHIFT, 3, movetoworkspace, 3"
-        "$mod SHIFT, 4, movetoworkspace, 4"
-        "$mod SHIFT, 5, movetoworkspace, 5"
-        "$mod SHIFT, 6, movetoworkspace, 6"
-        "$mod SHIFT, 7, movetoworkspace, 7"
-        "$mod SHIFT, 8, movetoworkspace, 8"
-        "$mod SHIFT, 9, movetoworkspace, 9"
-        "$mod SHIFT, 0, movetoworkspace, 10"
-
-        "$mod, v, togglefloating,"
-        "$mod, f, fullscreen,"
-        "$mod, left, movefocus, l"
-        "$mod, right, movefocus, r"
-        "$mod, up, movefocus, u"
-        "$mod, down, movefocus, d"
-        # "$mod, mouse:272, exec, kitty"
-
-        # Volume
-        ", XF86AudioPlay, exec, playerctl --all-players play-pause"    # Pause audio/video
-        ", XF86AudioMute, exec, volumectl toggle-mute"                 # Mute audio
-        ", XF86AudioMicMute, exec, volumectl -m toggle-mute"           # Mute mic
-
-        # Turn Off Laptop Display on Lid Close
-        ", switch:on:Lid Switch, exec, hyprctl dispatch dpms off"
-        ", switch:off:Lid Switch, exec, hyprctl dispatch dpms on"
-
-        # Screenshot
-        ", Print, exec, bash ~/.config/hypr/scripts/screenshot.sh"
-
-        # Color picker
-        "$mod, p, exec, bash ~/.config/hypr/scripts/colorpicker.sh"
-
-        # Lock pc
-        "$mod, L, exec, hyprlock"
-
-        "$mod, Q, killactive"
-        "$mod, D, exec, rofi -show drun"
-      ];
-
-      binde = [
-        # Brightness
-        ", XF86MonBrightnessUp, exec, lightctl up"
-        ", XF86MonBrightnessDown, exec, lightctl down"
-
-        # Volume
-        ", XF86AudioRaiseVolume, exec, volumectl -u up"   # Increase Volume
-        ", XF86AudioLowerVolume, exec, volumectl -u down" # Decrease Volume
-      ];
-
-      bindm = [
-        "$mod, mouse:272, movewindow"
-      ];
-    };
     extraConfig = ''
-      # window resize
-      bind = $mod, r, submap, resize
-      submap = resize
-      binde = , right, resizeactive, 10 0
-      binde = , left, resizeactive, -10 0
-      binde = , up, resizeactive, 0 -10
-      binde = , down, resizeactive, 0 10
-      bind = , escape, submap, reset
-      submap = reset
+      local mod = "SUPER"
+
+      hl.config({
+        general = {
+          gaps_in = 1,
+          gaps_out = 5,
+          col = {
+            inactive_border = colors.base,
+            active_border = colors.text,
+          },
+          resize_on_border = true,
+          extend_border_grab_area = 15,
+          hover_icon_on_border = true,
+          allow_tearing = true,
+          resize_corner = 3,
+        },
+
+        decoration = {
+          rounding = 10,
+          blur = {
+            enabled = false,
+          },
+          shadow = {
+            enabled = false,
+          },
+        },
+
+        animations = {
+          enabled = true,
+        },
+
+        input = {
+          kb_layout = "us",
+          numlock_by_default = false,
+
+          touchpad = {
+            disable_while_typing = true,
+            tap_to_click = true,
+            tap_and_drag = true,
+          },
+        },
+
+        misc = {
+          disable_hyprland_logo = true,
+          disable_splash_rendering = true,
+          background_color = accent,
+        },
+
+        cursor = {
+          inactive_timeout = 5,
+          hide_on_key_press = true,
+        },
+      })
+
+      hl.animation = ({ leaf = "windows", enabled = true, speed = 5, curve = "default", style = "popin 50%" })
+      hl.animation = ({ leaf = "workspaces", enabled = true, speed = 1, curve = "default", style = "fade" })
+
+      hl.gesture({
+        fingers = 3,
+        direction = "horizontal",
+        action = "workspace"
+      })
+
+      hl.on("hyprland.start", function()
+        hl.exec_cmd("awww query || awww-daemon & $HOME/.config/awww/awww_randomize.sh $HOME/.config/awww/wallpapers/wallpapers 60")
+        hl.exec_cmd("systemctl --user start hyprpolkitagent")
+
+        -- Stores only text data
+        hl.exec_cmd("wl-paste --type text --watch cliphist store")
+
+        -- Stores only image data
+        hl.exec_cmd("wl-paste --type image --watch cliphist store")
+
+        hl.exec_cmd("gammastep-indicator")
+      end)
+
+      for i = 1, 10 do
+        local key = i % 10 -- 10 maps to key 0
+        hl.bind(mod .. " + " .. key, hl.dsp.focus({ workspace = i}))
+        hl.bind(mod .. " + SHIFT + " .. key, hl.dsp.window.move({ workspace = i }))
+      end
+
+      hl.bind(mod .. " + v", hl.dsp.window.float())
+      hl.bind(mod .. " + f", hl.dsp.window.fullscreen({ mode = "fullscreen" }))
+      hl.bind(mod .. " + left", hl.dsp.focus({ direction = "left" }))
+      hl.bind(mod .. " + right", hl.dsp.focus({ direction = "right" }))
+      hl.bind(mod .. " + up", hl.dsp.focus({ direction = "up" }))
+      hl.bind(mod .. " + down", hl.dsp.focus({ direction = "down" }))
+
+      -- Turn Off Laptop Display on Lid Close
+      hl.bind("switch:on:Lid Switch", hl.dsp.exec_cmd("hyprctl dispatch dpms off"), { locked = true })
+      hl.bind("switch:off:Lid Switch", hl.dsp.exec_cmd("hyprctl dispatch dpms on"), { locked = true; })
+
+      -- Screenshot
+      hl.bind("Print", hl.dsp.exec_cmd("bash ~/.config/hypr/scripts/screenshot.sh"))
+
+      -- Color picker
+      hl.bind(mod .. " + p", hl.dsp.exec_cmd("bash ~/.config/hypr/scripts/colorpicker.sh"))
+
+      -- Lock pc
+      hl.bind(mod .. " + L", hl.dsp.exec_cmd("hyprlock"))
+
+      hl.bind(mod .. " + Q", hl.dsp.window.close())
+      hl.bind(mod .. " + D", hl.dsp.exec_cmd("rofi -show drun"))
+
+      -- Brightness
+      hl.bind("XF86MonBrightnessUp", hl.dsp.exec_cmd("lightctl up"), { repeating = true })
+      hl.bind("XF86MonBrightnessDown", hl.dsp.exec_cmd("lightctl down"), { repeating = true })
+
+      -- Volume
+      hl.bind("XF86AudioRaiseVolume", hl.dsp.exec_cmd("volumectl -u up"), { repeating = true })
+      hl.bind("XF86AudioLowerVolume", hl.dsp.exec_cmd("volumectl -u down"), { repeating = true })
+      hl.bind("XF86AudioMute", hl.dsp.exec_cmd("volumectl toggle-mute"))
+      hl.bind("XF86AudioMicMute", hl.dsp.exec_cmd("volumectl -m toggle-mute"))
+      hl.bind("XF86AudioPlay", hl.dsp.exec_cmd("playerctl --all-players play-pause"))
+      hl.bind("XF86AudioPrev", hl.dsp.exec_cmd("playerctl previous"))
+      hl.bind("XF86AudioNext", hl.dsp.exec_cmd("playerctl next"))
+
+      hl.bind(mod .. " + mouse:272", hl.dsp.window.drag(), { mouse = true })
+
+      -- submap resize
+      hl.bind(mod .. " + r", hl.dsp.submap("resize"))
+      hl.define_submap("resize", function()
+        -- Set repeating binds for resizing the active window.
+        hl.bind("right", hl.dsp.window.resize({ x = 10, y = 0, relative = true}), { repeating = true })
+        hl.bind("left", hl.dsp.window.resize({ x = -10, y = 0, relative = true}), { repeating = true })
+        hl.bind("up", hl.dsp.window.resize({ x = 0, y = 10, relative = true}), { repeating = true })
+        hl.bind("down", hl.dsp.window.resize({ x = 0, y = -10, relative = true}), { repeating = true })
+
+        -- Use `reset` to go back to the global submap
+        hl.bind("escape", hl.dsp.submap("reset"))
+      end)
     '';
   };
 

--- a/home/common/gnu-linux/hyprland/hyprland.nix
+++ b/home/common/gnu-linux/hyprland/hyprland.nix
@@ -11,6 +11,10 @@
       local mod = "SUPER"
 
       hl.config({
+        ecosystem = {
+          no_update_news = true,
+          no_donation_nag = true,
+        },
         general = {
           gaps_in = 1,
           gaps_out = 5,

--- a/home/monolith/hyprland/hyprland.nix
+++ b/home/monolith/hyprland/hyprland.nix
@@ -1,13 +1,29 @@
 _: {
-  wayland.windowManager.hyprland.settings = {
-    monitor = [
-      "DP-1, 5120x1440@120, 0x0, 1"
-      "DP-2, preferred, 5120x0, 1"
-    ];
+  wayland.windowManager.hyprland.extraLuaFiles = {
+    "monitors" = {
+      content = ''
+        hl.monitor({
+          output = "DP-1",
+          mode = "5120x1440@120",
+          position = "0x0",
+          scale = "1",
+        })
+        hl.monitor({
+          output = "DP-2",
+          mode = "preferred",
+          position = "5120x0",
+          scale = "1",
+        })
+      '';
+      autoLoad = true;
+    };
 
-    env = [
-      "LIBVA_DRIVER_NAME,nvidia"
-      "__GLX_VENDOR_LIBRARY_NAME,nvidia"
-    ];
+    "extraEnv" = {
+      content = ''
+        hl.env("LIBVA_DRIVER_NAME", "nvidia")
+        hl.env("__GLX_VENDOR_LIBRARY_NAME", "nvidia")
+      '';
+      autoLoad = true;
+    };
   };
 }


### PR DESCRIPTION
This pull request refactors the Hyprland configuration to use Lua-based configuration instead of the traditional Nix `settings` attribute, modernizing the setup and enabling more dynamic and maintainable configuration management. It also updates package references and enables the pointer cursor by default.

**Migration to Lua-based configuration:**

* Replaces the old `settings`-based Hyprland configuration with Lua-based configuration using `extraConfig` and `extraLuaFiles`, allowing for more expressive and flexible setup in `hyprland.nix` files (`home/common/gnu-linux/hyprland/hyprland.nix`, `home/bubule/hyprland/hyprland.nix`, `home/monolith/hyprland/hyprland.nix`). [[1]](diffhunk://#diff-3e33aeee725196a40b2883dd168192e7b734a128e1cdd2413cd6fc560288e2a9L1-R142) [[2]](diffhunk://#diff-ee3d09e4648c2a13b1f38ad05a65caaf7d7ac37bfbd529b52631d2268097ec37L2-R14) [[3]](diffhunk://#diff-df77b0fdaab93aaa331da50f446ea3356fef9f2e5e905ac84cbdc2bd3f85bf4bL2-R27)
* Moves monitor definitions and environment variable setup into Lua files loaded via `extraLuaFiles`, replacing static Nix lists with Lua functions for monitor and environment configuration (`home/bubule/hyprland/hyprland.nix`, `home/monolith/hyprland/hyprland.nix`). [[1]](diffhunk://#diff-ee3d09e4648c2a13b1f38ad05a65caaf7d7ac37bfbd529b52631d2268097ec37L2-R14) [[2]](diffhunk://#diff-df77b0fdaab93aaa331da50f446ea3356fef9f2e5e905ac84cbdc2bd3f85bf4bL2-R27)

**Configuration improvements:**

* Updates the Hyprland configuration to explicitly set `configType = "lua"`, ensuring the correct configuration format is used (`home/common/gnu-linux/hyprland/hyprland.nix`).
* Refactors keybindings, workspace logic, and startup commands into Lua, making them more maintainable and dynamic (`home/common/gnu-linux/hyprland/hyprland.nix`).

**Package and cursor updates:**

* Switches Qt Wayland package references to use `qt6.qtwayland` and `qt5.qtwayland` instead of the older `kdePackages` and `libsForQt5` aliases, improving clarity and compatibility (`home/common/gnu-linux/hyprland/default.nix`).
* Enables the pointer cursor by default and ensures the Catppuccin cursor theme is applied (`home/common/gnu-linux/hyprland/default.nix`).