### PR TITLE
chore: flake upgrade

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1779099919,
-        "narHash": "sha256-SmjBZYOBi9vi7GrgWgEzEXjeX5rxVWl6TVsf+i+Xexg=",
+        "lastModified": 1784540777,
+        "narHash": "sha256-GDl4LUXqwkw1TEXbEdF7m0E80yzUxWIWT+JU+UF9fNM=",
         "owner": "amber-lang",
         "repo": "Amber",
-        "rev": "4facdf99baf11aebe1254b0ba49855138dad3a61",
+        "rev": "75139a7012e7975e38e530fe5cf9ad1cf0154c66",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778857089,
-        "narHash": "sha256-TclWRW2SdFeETLaiTG4BA8C8C4m/LppQEldncqyTzAQ=",
+        "lastModified": 1784368054,
+        "narHash": "sha256-zF1iJkBQSDWmRO4/LEeHR1SpKY0lqZaxkoQJpPS9K9U=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "ab2b0af63fbc9fb779d684f19149b790978be8a8",
+        "rev": "9b5f14d9483445e766294eb8fbe0b8f370269ed0",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1777136912,
-        "narHash": "sha256-owyQdC2vi0kYC119fzyVQp0J4G0t1n4xXUwryhlBbqA=",
+        "lastModified": 1784030954,
+        "narHash": "sha256-MPMVSBhSEl+ShSrWVN5qH3FiX2gg8LbYA8L3nuQw5VE=",
         "ref": "refs/heads/main",
-        "rev": "f66e12a76dbc4c669b2f1375f78bce49f5b19d66",
-        "revCount": 1363,
+        "rev": "25ea4fd7a42359379da9ddadedda1c477caa4ae0",
+        "revCount": 1376,
         "type": "git",
         "url": "https://codeberg.org/LGFae/awww"
       },
@@ -79,11 +79,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1779446167,
-        "narHash": "sha256-95gfnivOKw+zleITz2OptawwTeSs36Y9u+qeU0xdqT8=",
+        "lastModified": 1784366307,
+        "narHash": "sha256-VKatYOZwLQ+MuNkWH6/gZYxrNeSK1Mqb7mC0H1WSu+M=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "229ede9cec873986144e222b2c61c2f239c16125",
+        "rev": "673f730d0fc8db3468c51575f1d3d777cc55e51f",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1766810506,
-        "narHash": "sha256-I4BxozsEu205tA7jazufztI8ZQ5p7hcCnjqrSKPz9nI=",
+        "lastModified": 1782994178,
+        "narHash": "sha256-VGc3/2fe6hnOmNSLlOygEAbeS69v7A7rjKDKRzAgE2Q=",
         "owner": "hraban",
         "repo": "cl-nix-lite",
-        "rev": "038e341cede255a83a8f04af114dc95717461d32",
+        "rev": "eb584721e5e799bafe0c6210a8a1a398f90e8ac0",
         "type": "github"
       },
       "original": {
@@ -169,11 +169,11 @@
     "flake-compat_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1730663653,
-        "narHash": "sha256-kFCUWettiFHDIqxCWWQ9qY8pVh+Lj+XL0Giyy/kdomg=",
+        "lastModified": 1766808011,
+        "narHash": "sha256-s83BS0abtIj7vzUf8JE0209KphfHA6qRw/92D9k/F+0=",
         "owner": "hraban",
         "repo": "flake-compat",
-        "rev": "e5b16676185cb7548581c852f51ce7f3a49bba5e",
+        "rev": "6e0aafdc4c4c2043c66f756d5045374b42184fc5",
         "type": "github"
       },
       "original": {
@@ -252,11 +252,11 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -270,11 +270,11 @@
         "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
-        "lastModified": 1777988971,
-        "narHash": "sha256-qIoWPDs+0/8JecyYgE3gpKQxW/4bLW/gp45vow9ioCQ=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "0678d8986be1661af6bb555f3489f2fdfc31f6ff",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -326,68 +326,26 @@
     },
     "git-hooks": {
       "inputs": {
-        "flake-compat": "flake-compat_4",
-        "gitignore": "gitignore_2",
+        "flake-compat": [
+          "nix-gaming",
+          "flake-compat"
+        ],
         "nixpkgs": [
           "nix-gaming",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1778507602,
-        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "lastModified": 1784288435,
+        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "hyprland",
-          "pre-commit-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "gitignore_2": {
-      "inputs": {
-        "nixpkgs": [
-          "nix-gaming",
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -398,11 +356,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779507042,
-        "narHash": "sha256-7wOwi8B6D0BYsieZCnHZZj2sNUzgJhLoIVSfkwB7lxQ=",
+        "lastModified": 1784588016,
+        "narHash": "sha256-ouZe80aWEhMLVMkqICFDN+JUw+0FJtCr/bh+hHtRtMg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "509ed3c603349a9d43de9e2ae6613baea6bd5b34",
+        "rev": "deeb6b7eb7e0c44ae1819c051ce175bd92a85100",
         "type": "github"
       },
       "original": {
@@ -477,11 +435,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776426399,
-        "narHash": "sha256-RUESLKNikIeEq9ymGJ6nmcDXiSFQpUW1IhJ245nL3xM=",
+        "lastModified": 1782566056,
+        "narHash": "sha256-haEZcHzYrePnjFOYSWTbxm/Nrla0aPslJfmvdCvqtVc=",
         "owner": "hyprwm",
         "repo": "hyprgraphics",
-        "rev": "68d064434787cf1ed4a2fe257c03c5f52f33cf84",
+        "rev": "c6e7b9f673f4360bc813d3dc75028f75ee88d3f8",
         "type": "github"
       },
       "original": {
@@ -507,11 +465,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1779538437,
-        "narHash": "sha256-QTVm1lfienmW8sjcdnqwpffgMG8QPc+hBXUmZjQJOYs=",
+        "lastModified": 1784641930,
+        "narHash": "sha256-j1c/65skFvp1WPbHBlAfVWaeCz0Bgwr/WPwIg0H+Ncg=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "55b404b0a13518da3252cb176cf4a5a6ce9df2be",
+        "rev": "1a3606234c59842340ad9a42baeeffe44a9d6cda",
         "type": "github"
       },
       "original": {
@@ -553,11 +511,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776426575,
-        "narHash": "sha256-KI6nIfVihn/DPaeB5Et46Xg3dkNHrrEtUd5LBBVomB0=",
+        "lastModified": 1784196523,
+        "narHash": "sha256-ahtKMGXFJdlQNhatQm1+BBU/pGfGYnAqQt3vWvq4p8s=",
         "owner": "hyprwm",
         "repo": "hyprland-guiutils",
-        "rev": "a968d211048e3ed538e47b84cb3649299578f19d",
+        "rev": "a6ccb6cb112ed5a244c0191fb972347ecfa893e0",
         "type": "github"
       },
       "original": {
@@ -659,11 +617,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772462885,
-        "narHash": "sha256-5pHXrQK9zasMnIo6yME6EOXmWGFMSnCITcfKshhKJ9I=",
+        "lastModified": 1782554491,
+        "narHash": "sha256-+p3MlyN/nqRefcf2IckPlGRUn9+hielqpS9XClbLleM=",
         "owner": "hyprwm",
         "repo": "hyprtoolkit",
-        "rev": "9af245a69fa6b286b88ddfc340afd288e00a6998",
+        "rev": "bdba25ced39ea39ab004a8f31593ba0b0ff1ca35",
         "type": "github"
       },
       "original": {
@@ -684,11 +642,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779475241,
-        "narHash": "sha256-Nw4DN0A5krWNcPBvuWe5Gz2yuxsUUPiDgtu6SVPJQeU=",
+        "lastModified": 1784323413,
+        "narHash": "sha256-XnAVV+H4f8Xdv0yZcSwJ5kCjLyE8fHxPeLX6a3HSrAU=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "3cd3972b2ee658a14d2610d8494e09259e530124",
+        "rev": "5f03477ab3a005ff27c527486f551883535aea2f",
         "type": "github"
       },
       "original": {
@@ -776,11 +734,11 @@
         "rust-overlay": "rust-overlay_3"
       },
       "locked": {
-        "lastModified": 1779182766,
-        "narHash": "sha256-ObXytXej27SZQ3iVOqcbA2MwlXZIUAP/DNNUAsIjuuw=",
+        "lastModified": 1782656559,
+        "narHash": "sha256-i2xXiqLOnCNfwZnbrm1teVlTTA1HQ0IRVPXEiyiQtpU=",
         "owner": "feschber",
         "repo": "lan-mouse",
-        "rev": "a9461ae830ea91c5d2bce0c78c405217fd8f91c5",
+        "rev": "392af44cbe06a7a591db86856ad6ed2aa83958d8",
         "type": "github"
       },
       "original": {
@@ -799,11 +757,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1766810876,
-        "narHash": "sha256-VPElWFQIiP31lXQXEom+L4sl85alZpZn33O4hewsP9k=",
+        "lastModified": 1783182903,
+        "narHash": "sha256-7IteXipJZfFepi5zakxe0jQ5i3vRBQguk0+Gtte1Fu4=",
         "owner": "hraban",
         "repo": "mac-app-util",
-        "rev": "4747968574ea58512c5385466400b2364c85d2d0",
+        "rev": "039f33deef21782d4db97087f426504951239887",
         "type": "github"
       },
       "original": {
@@ -841,11 +799,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779036909,
-        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
+        "lastModified": 1784500460,
+        "narHash": "sha256-UvORnAxTRHax7RG74W8Z2t4GvIkX6AjJ5kk0QlwZomo=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "56c666e108467d87d13508936aade6d567f2a501",
+        "rev": "57a3171f94705599a2499248ca5758d5eb47c0e0",
         "type": "github"
       },
       "original": {
@@ -857,16 +815,17 @@
     },
     "nix-gaming": {
       "inputs": {
+        "flake-compat": "flake-compat_4",
         "flake-parts": "flake-parts_2",
         "git-hooks": "git-hooks",
         "nixpkgs": "nixpkgs_11"
       },
       "locked": {
-        "lastModified": 1779507984,
-        "narHash": "sha256-Fyege4MHeyrof0dlnScWjsxQl9JBeck4svJjggTXOjU=",
+        "lastModified": 1784431599,
+        "narHash": "sha256-B80p0N3Uqx4+nMl/rFK/SU+1i3UNkAAMP7TaUk1ug20=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "3b36ed6ed66168c752ad0eba1274937b8a7e3c40",
+        "rev": "1aef499f40964840bf28c8e5a47ac7e8009a7e7e",
         "type": "github"
       },
       "original": {
@@ -880,11 +839,11 @@
         "nixpkgs": "nixpkgs_12"
       },
       "locked": {
-        "lastModified": 1779507994,
-        "narHash": "sha256-vw/u69n4vPibpWNUVkbwlfVHQukg3xcuKoHwCXJkOvc=",
+        "lastModified": 1784603886,
+        "narHash": "sha256-AwdtZq1mpXZCfn+C2NOBTO7i0H4eGIj6dH9XXkO3Kus=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "375f9dc68aa90ccff57891af5dfe1d5fb2a9b20a",
+        "rev": "3bc93178a45e4327bdcf91f2c9158701937abdf3",
         "type": "github"
       },
       "original": {
@@ -894,12 +853,15 @@
       }
     },
     "nixos-hardware": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_13"
+      },
       "locked": {
-        "lastModified": 1779258371,
-        "narHash": "sha256-j1iZsLy6oFApqR1oiDmHhvkwxXqcNi0aoSJj643LuwU=",
+        "lastModified": 1784310968,
+        "narHash": "sha256-rkSPTePrKqs4dg+i7ZFCq93+HrClac6oSwXX927SVjA=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "c97bc4d15bd3473dd095e8e8ba57330ab1943a77",
+        "rev": "779c32a00155994c86cde8213a8dd4df139d4355",
         "type": "github"
       },
       "original": {
@@ -942,11 +904,11 @@
     },
     "nixpkgs-lib_2": {
       "locked": {
-        "lastModified": 1777168982,
-        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
         "type": "github"
       },
       "original": {
@@ -957,11 +919,11 @@
     },
     "nixpkgs-lib_3": {
       "locked": {
-        "lastModified": 1777168982,
-        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
         "type": "github"
       },
       "original": {
@@ -974,17 +936,17 @@
       "inputs": {
         "flake-compat": "flake-compat_5",
         "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_14",
+        "nixpkgs": "nixpkgs_15",
         "nvfetcher": "nvfetcher",
         "systems": "systems_5",
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1779505709,
-        "narHash": "sha256-yePAKD3X68ExEk+rZDOEXCH1y0bUSTbtOzPaiZfhT+4=",
+        "lastModified": 1784428803,
+        "narHash": "sha256-zBWjiZOrNB4PvTzMQY7Ll9RRe3obGFC3egKaxVE9GIs=",
         "owner": "nix-community",
         "repo": "nixpkgs-xr",
-        "rev": "8e2ce138c168499500f209a39c618cc4aef45e53",
+        "rev": "28fe56a7bed09a33a82225f5cc48e343c2a5cd04",
         "type": "github"
       },
       "original": {
@@ -995,11 +957,11 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1761236834,
-        "narHash": "sha256-+pthv6hrL5VLW2UqPdISGuLiUZ6SnAXdd2DdUE+fV2Q=",
+        "lastModified": 1770107345,
+        "narHash": "sha256-tbS0Ebx2PiA1FRW8mt8oejR0qMXmziJmPaU1d4kYY9g=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d5faa84122bc0a1fd5d378492efce4e289f8eac1",
+        "rev": "4533d9293756b63904b7238acb84ac8fe4c8c2c4",
         "type": "github"
       },
       "original": {
@@ -1011,11 +973,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1784364478,
+        "narHash": "sha256-CdItYNdYUlm7NxqMVyQKqT2IxTwvapiPuRLWOyHTrbY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "20535e48e12c86043b577b8518234ff5dbb26957",
         "type": "github"
       },
       "original": {
@@ -1043,37 +1005,50 @@
     },
     "nixpkgs_13": {
       "locked": {
-        "lastModified": 1779357205,
-        "narHash": "sha256-cCO8aTqss5x9Ky8GWkpY0Hy5fyTZEbtifSUV8QjSzic=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "f83fc3c307e74bc5fd5adb7eb6b8b13ffd2a36e1",
-        "type": "github"
+        "lastModified": 1767892417,
+        "narHash": "sha256-8bW3q88CEg2u4hSP66Vf4lpbLonHz7hqDNBMcCY7E9U=",
+        "rev": "3497aa5c9457a9d88d71fa93a4a8368816fbeeba",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre924538.3497aa5c9457/nixexprs.tar.xz"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
       }
     },
     "nixpkgs_14": {
       "locked": {
-        "lastModified": 1779357205,
-        "narHash": "sha256-cCO8aTqss5x9Ky8GWkpY0Hy5fyTZEbtifSUV8QjSzic=",
-        "owner": "NixOS",
+        "lastModified": 1784497964,
+        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f83fc3c307e74bc5fd5adb7eb6b8b13ffd2a36e1",
+        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
+        "owner": "nixos",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_15": {
+      "locked": {
+        "lastModified": 1784356753,
+        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_16": {
       "locked": {
         "lastModified": 1719082008,
         "narHash": "sha256-jHJSUH619zBQ6WdC21fFAlDxHErKVDJ5fpN0Hgx4sjs=",
@@ -1089,13 +1064,13 @@
         "type": "github"
       }
     },
-    "nixpkgs_16": {
+    "nixpkgs_17": {
       "locked": {
-        "lastModified": 1777954456,
-        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
         "type": "github"
       },
       "original": {
@@ -1123,27 +1098,24 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
-        "type": "github"
+        "lastModified": 1783279667,
+        "narHash": "sha256-2l8yOB5aYd+05Q9V9Y1YhgbSa1j1o5QX+nvYs5FL80A=",
+        "rev": "f205b5574fd0cb7da5b702a2da51507b7f4fdd1b",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.11pre1028110.f205b5574fd0/nixexprs.tar.xz"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz"
       }
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1779357205,
-        "narHash": "sha256-cCO8aTqss5x9Ky8GWkpY0Hy5fyTZEbtifSUV8QjSzic=",
+        "lastModified": 1784356753,
+        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f83fc3c307e74bc5fd5adb7eb6b8b13ffd2a36e1",
+        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
         "type": "github"
       },
       "original": {
@@ -1187,11 +1159,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1766736597,
-        "narHash": "sha256-BASnpCLodmgiVn0M1MU2Pqyoz0aHwar/0qLkp7CjvSQ=",
+        "lastModified": 1779796641,
+        "narHash": "sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f560ccec6b1116b22e6ed15f4c510997d99d5852",
+        "rev": "25f538306313eae3927264466c70d7001dcea1df",
         "type": "github"
       },
       "original": {
@@ -1219,17 +1191,17 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1732617236,
-        "narHash": "sha256-PYkz6U0bSEaEB1al7O1XsqVNeSNS+s3NVclJw7YC43w=",
+        "lastModified": 1782999065,
+        "narHash": "sha256-5Dgj5+pIQYZKrXUGaLCk7CKfN3MmpwIhO94++WVxvng=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "af51545ec9a44eadf3fe3547610a5cdd882bc34e",
+        "rev": "80d591ed473cfc46329932c2aadac9b435342c7c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
-        "rev": "af51545ec9a44eadf3fe3547610a5cdd882bc34e",
         "type": "github"
       }
     },
@@ -1266,18 +1238,17 @@
     "pre-commit-hooks": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "gitignore": "gitignore",
         "nixpkgs": [
           "hyprland",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1778507602,
-        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "lastModified": 1784288435,
+        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
         "type": "github"
       },
       "original": {
@@ -1289,16 +1260,16 @@
     "pyprland": {
       "inputs": {
         "flake-compat": "flake-compat_6",
-        "nixpkgs": "nixpkgs_15",
+        "nixpkgs": "nixpkgs_16",
         "pyproject-nix": "pyproject-nix",
         "systems": "systems_6"
       },
       "locked": {
-        "lastModified": 1779176151,
-        "narHash": "sha256-FupUgkr2wRz0XuYPozKnJQGvaJI9GhrhN4aH1NW+V3o=",
+        "lastModified": 1783764661,
+        "narHash": "sha256-foECW2uv1D2t2NTZ6/WVhdfFEvd63ipORXE4di3Rb7E=",
         "owner": "hyprland-community",
         "repo": "pyprland",
-        "rev": "22a5ab04595be5883fe8e0b38da1e40de3443bb1",
+        "rev": "26dfa7f93a2b3d770e67308bd13033f12e27b8b2",
         "type": "github"
       },
       "original": {
@@ -1343,7 +1314,7 @@
         "nix-gaming": "nix-gaming",
         "nix-vscode-extensions": "nix-vscode-extensions",
         "nixos-hardware": "nixos-hardware",
-        "nixpkgs": "nixpkgs_13",
+        "nixpkgs": "nixpkgs_14",
         "nixpkgs-xr": "nixpkgs-xr",
         "pyprland": "pyprland",
         "sops-nix": "sops-nix",
@@ -1420,11 +1391,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777944972,
-        "narHash": "sha256-VfGRo1qTBKOe3s2gOv8LSoA6Fk19PvBlwQ1ECN0Evn8=",
+        "lastModified": 1783174389,
+        "narHash": "sha256-aCWC8ngycU7OdJrU2+Je3qf+1a2ykuBvpPhZT/9tXMc=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "c591bf665727040c6cc5cb409079acb22dcce33c",
+        "rev": "f1406619a3884cd5c47992a70b8b35c9c0fcb4c9",
         "type": "github"
       },
       "original": {
@@ -1526,14 +1497,14 @@
     "talhelper": {
       "inputs": {
         "flake-parts": "flake-parts_3",
-        "nixpkgs": "nixpkgs_16"
+        "nixpkgs": "nixpkgs_17"
       },
       "locked": {
-        "lastModified": 1779505362,
-        "narHash": "sha256-cJ7EXHbr8hdPJeeiOm2kFIPsPE5nmRleYzv16Drzy6U=",
+        "lastModified": 1784598873,
+        "narHash": "sha256-uxTuQTaN+NleQnoj7vsoZvn4e7a8tY6H3KQHS7dx3Bs=",
         "owner": "budimanjojo",
         "repo": "talhelper",
-        "rev": "ecaaefd7f818289fccfee8c8d2de7377736cace6",
+        "rev": "2114982b88136c7a63315460988ba36e4ce70fb4",
         "type": "github"
       },
       "original": {
@@ -1565,11 +1536,11 @@
         "nixpkgs": "nixpkgs_10"
       },
       "locked": {
-        "lastModified": 1766000401,
-        "narHash": "sha256-+cqN4PJz9y0JQXfAK5J1drd0U05D5fcAGhzhfVrDlsI=",
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "42d96e75aa56a3f70cab7e7dc4a32868db28e8fd",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
         "type": "github"
       },
       "original": {
@@ -1586,11 +1557,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775636079,
-        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "lastModified": 1784369104,
+        "narHash": "sha256-47cxbcZODibHv3rELFQ9vZly0vUNkND/atn/U7HLeb0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "rev": "df3c0640565d04a0261253cdd89fce78ec50168a",
         "type": "github"
       },
       "original": {
@@ -1645,11 +1616,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778265244,
-        "narHash": "sha256-8jlPtGSsv/CQY6tVVyLF4Jjd0gnS+Zbn9yk/V13A9nM=",
+        "lastModified": 1784371182,
+        "narHash": "sha256-S8A1lezEalltWcCp3gAic5lssS0xTSISK6fKODefhOk=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "813ea5ca9a1702a9a2d1f5836bc00172ef698968",
+        "rev": "08d99f727944dd15e4740090305e31c5fb92a50a",
         "type": "github"
       },
       "original": {

--- a/home/bubule/home.nix
+++ b/home/bubule/home.nix
@@ -14,6 +14,7 @@
   # https://nix.catppuccin.com/search/rolling/
   catppuccin = {
     enable = true;
+    autoEnable = true;
     # flavor = "macchiato";
     flavor = "mocha";
   };

--- a/home/ceramiq/home.nix
+++ b/home/ceramiq/home.nix
@@ -16,6 +16,7 @@
   # https://nix.catppuccin.com/search/rolling/
   catppuccin = {
     enable = true;
+    autoEnable = true;
     # flavor = "macchiato";
     flavor = "mocha";
   };

--- a/home/common/gnu-linux/programs/default.nix
+++ b/home/common/gnu-linux/programs/default.nix
@@ -66,11 +66,11 @@
     socat # replacement of openbsd-netcat
     tcpdump
     vlan
-    # wireshark
+    wireshark
 
     # CAD / graphics
     blender
-    freecad
+    # freecad
     gimp
     inkscape
     orca-slicer

--- a/home/monolith/home.nix
+++ b/home/monolith/home.nix
@@ -15,6 +15,7 @@
   # https://nix.catppuccin.com/search/rolling/
   catppuccin = {
     enable = true;
+    autoEnable = true;
     # flavor = "macchiato";
     flavor = "mocha";
   };

--- a/hosts/common/gnu-linux/default.nix
+++ b/hosts/common/gnu-linux/default.nix
@@ -1,4 +1,4 @@
-_: {
+{ pkgs, ... }: {
   imports = [
     ./greeter.nix
     ./locales.nix
@@ -12,4 +12,9 @@ _: {
   ];
 
   environment.pathsToLink = [ "/share/xdg-desktop-portal" "/share/applications" ];
+
+  environment.systemPackages = [
+    # https://nixos.wiki/wiki/Android
+    pkgs.android-tools
+  ];
 }

--- a/hosts/common/gnu-linux/greeter.nix
+++ b/hosts/common/gnu-linux/greeter.nix
@@ -1,25 +1,7 @@
-{ pkgs, ... }: {
+{ pkgs, lib, ... }: {
   environment.systemPackages = [
     pkgs.tuigreet
   ];
-
-  # programs.regreet = {
-  #   enable = true;
-  #   # font = {
-  #   #   name = "";
-  #   # };
-  # };
-
-  # # Hyprland config for greetd.regreet
-  # hyprlanRegreet = pkgs.writeText "hyprland_regreet"
-  # ''
-  #   exec-once = regreet; hyprctl dispatch exit
-  #   misc {
-  #     disable_hyprland_logo = true
-  #     disable_splash_rendering = true
-  #     disable_hyprland_qtutils_check = true
-  #   }
-  # '';
 
   # Enable Display Manager
   services.greetd = {
@@ -27,13 +9,13 @@
     settings = {
       default_session = {
         # https://github.com/apognu/tuigreet?tab=readme-ov-file
-        command = ''
-          ${pkgs.tuigreet}/bin/tuigreet \
-            --time --time-format '%H:%M | %a • %h | %F' \
-            --cmd Hyprland
-        '';
-        # command = "Hyprland --config ${hyprlanRegreet}";
-        # user = "${username}";
+        command = lib.concatStrings [
+          "${pkgs.tuigreet}/bin/tuigreet "
+          "--time --time-format '%H:%M | %a • %h | %F' "
+          "--power-shutdown 'systemctl poweroff' "
+          "--power-reboot 'systemctl reboot' "
+          "--cmd start-hyprland"
+        ];
         user = "greeter";
       };
     };

--- a/hosts/monolith/games.nix
+++ b/hosts/monolith/games.nix
@@ -27,8 +27,6 @@
   };
 
   environment.systemPackages = with pkgs; [
-    # https://nixos.wiki/wiki/Android
-    android-tools
     # bottles
     (heroic.override {
       extraPkgs = pkgs: [

--- a/secrets/bubule/secrets.yaml
+++ b/secrets/bubule/secrets.yaml
@@ -1,11 +1,10 @@
 password_hash: ENC[AES256_GCM,data:j3SJRLjn5sURWUFbN71zgg6/p+yUieI59qe2XREhqrxIAzipn/IrXtyR/rvZaSzAuO5a5VWLF6Fqwb8WRmdQMFeZzQT5kR7vqw==,iv:iZDBc+UDjiFnxHRCzelhK6aUo/OYPzD936nNhM31EEc=,tag:WrpS3nM2I9alV564oocxSA==,type:str]
 wireguard:
-  homelab: ENC[AES256_GCM,data:2SwuVGckfjA2PKoy0x/l6tkPpHFvh2mFd9M+oPX1nQ1mssOSb54AvXYCOKpw/ETbAXPNsTNua9PDuG8FVMHIn1nuDSoNXuEA7XVhJlCoz7WPEV8EgHn75jz1FxmiFQ7608D+Y/FB4syUX8hLm1TqWgV3y4/op2s3BnB4mFUnGtDpFSeYGo4s80cww7jPh4WhT7W5eGo571ZI3xHD/PjmIvwhaOvSHcMouucsyHZGLh/ZYuiYQ4RlwMjiVuJnm2J1FFhQ7tnnCXG07BXF0FmQrDoD+yB80U4WQy9kOb2XjNw3+p2nX40EbL3LlpBBQjLb1TuucytC02BqkJUe6W3Ow4vGhYL99Lktw7gBGeCPxVPrrNTqTasVYHOFEtMOqlKb9i8E5/4eIPBzPQOC/07iXSvHtrf67Uwfzl8ruMa74B5wTGKN6y67auciTqfDEipKxujMS9dUuzAE9vJH9IOonswQ2uSJxhNimzLRlf6CsLSHuvvdbP0rviDbmlWhPV/kYnwiQdlcb8bYdZSTS1pV1mdG/N9bO3kObTbq/QIGw9ETkLcXq4vSRZW0douSaXWtbT7F,iv:l+Itp5z13TlkE1U/l0SgGCRhTMThjC9F0VcGSQrz6wo=,tag:eIJkjATmDQG+PB0SUcWd4g==,type:str]
+  homelab: ENC[AES256_GCM,data:wNHYysUzggjbviWTUVhOtuQNDw6ukPQPQ+nSYrlxb1LE/Kpu8v6r1YtsHn2pGv+0zU9CV7myOF2dp2CeL573MVVoczRKYIL8tnRu7fITkej1o4BEMC/ynrKhjrO1dbG+piHyCLgMMoSdVOsCAyRukBdDZnuHVJEj4lbMWHIfBXiDT9iAW8xDmRGvAr+WKvuOAYNzzl+aYH7djbaAELub0iti4xNg2BoLBrlL26MOe5v/0mRNNxvEszos0eK1jJ4/6zmapWnXeNA90S004A8UO/sHMz5d31SmbVgwI6pH76HmAamz11HJeF+8WBS3xx0zk342p0rvvJU2ElYU1X+uKSDr3rBNevGcr1mMViTba4386t1Ueu78BUOqP5CNmjbRdCkDvCPSgWiw2f6TBDFHVllJ3iQ/JjnV0USeUcAyxCzOIufF2sDEwnR5ekaRpcNLtLs07kocCIZSeFVvPMY+jvO61c1R6/IsMgTxYMSGPqSlZi/gqGmhBHwYyV+Xf9Q21BTjWStoW8nCuXJMfFpC1cuplm4Rn61zEYphm6mhZOWigxlhnOL1+mFeuDGF3CYw0HkV,iv:TubxMqQbFdgX0lIWWp3lc++U/WBEBdfSn2BW/7GskYU=,tag:79+gCshF20T1VG1fYCziMg==,type:str]
 ssh_key: ENC[AES256_GCM,data:I3UA0DKcAyScWtwIOj60oTG2mYL4TWL7NVG7iD9vNeEn+CnRHbYeyRvCDm9wYc4c+D0pSPvcfs/aesxiUdSgSSxYP2HjHSrLS1jnXVuDLvmmYvoptzClxkO6+U2NHCfYsMamnTdZZrnQuviggK9w4dTDeZdng73xUaYJkJ0Ez2Y0+vR5D7JXfzFieqLyosQDmQ3602RHckEtdSaMCFBuYn2f5acbDZml0iKPimtguvusabxKmbLUrqxutWUeoMhohyUa9OLiR44upTxzud1uiJEwbPtgevqWzHetUm1MZlMWHioN80uLVzXwLeJbMQj+HfWxhXFaoyxrxldaZOZHTq5D9VfJu/AYfB7dgqeUjizOVnccOEPy4eWsbqDeQv73jif8MKwU79lPxjCL1mQkmo7QQZoj8vWABTqD3sE2VbwSaffzxOkUCxU/gkoP7uhxlgFpZggKvKDozjtCMhCJHu2Vsdt1MoClaKb0uDMTmHv5J4sUW0OqhSOZ+iLqZtcU1HnwL5w6hPTf+g2Dlw15PmW4NfjvhQ7uqpxH,iv:3bxMowEQZ91vKMI5ejZHqaC3MstzXsaHTNLmIyomAKg=,tag:x2BeQf0Zp/PwWP8QWC77ew==,type:str]
 sops:
   age:
-    - recipient: age195m7v6w6lce8knleuc9juqwklj56vjflng64q60eh90yrfpsfyjs222pls
-      enc: |
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
         YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsa3daRWU2aEQreGZ4bnZi
         SDczMEFIN0ppZW5temRKb2NFSW9PVDV5S2xRCjJrTStjelRNS3VWekNFM2FGMDVN
@@ -13,7 +12,8 @@ sops:
         ak0wMjgvRm9pVmJULzdZdjQ3THJ2alkKwEGiljS26a61TSD7Vfk8aPqJ8HhQ9ycR
         mXZPLxabZFJGnj/xuMkmZohwZuajQITMekhtVemNSSp6hg64KsTBXw==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2025-10-23T15:28:47Z"
-  mac: ENC[AES256_GCM,data:00S9qYY9LzZ2id6nFFnwETDmdOSZAlEd1xieGiXRpSXw+yq3Ulx1hRJ0yKl4qJKHEbtIl2DYZ9CzPAknqtm+aQoyd3DLtAqjJAu17MkWQ+/rFElGXXfzsSHcHD9hckC+8ltMGe6pA0ik7JMtQu66RLSPHEQ3fXTF7tZq+/AUVfY=,iv:3Bn0dVMmUoi812Y0Pbw+oxulh2UWbYGfLkNwyQ36NZQ=,tag:5KFtgf8UFN9oS/VQ6yIPQg==,type:str]
+      recipient: age195m7v6w6lce8knleuc9juqwklj56vjflng64q60eh90yrfpsfyjs222pls
+  lastmodified: "2026-07-08T12:20:26Z"
+  mac: ENC[AES256_GCM,data:c/02uGswL8qJh9NHFx265dED7Ufw6GJ7qitR4cZTvNYXkUMe7O6VS2WEfx4l4aWAUtB67vbuBhfbdXwCYuldg/DA3KqtQcT4/x+UegIheHHRy9OIioq1dfM3NcXNdfvgwgp6uYisTsWtmlHSwiTqnvgMgwfIT0EZq3IQxLrTj5A=,iv:1xII1yfnGaj+T+UgBeTsfcVqlECUA3rSjfaFR/6UlPU=,tag:sZ20AurviU1RFW+1af6LAw==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.11.0
+  version: 3.13.1

--- a/secrets/monolith/secrets.yaml
+++ b/secrets/monolith/secrets.yaml
@@ -1,11 +1,10 @@
 password_hash: ENC[AES256_GCM,data:y0Go7UA/8tp8KyqfJv93SqzJVys/1JQuBeHHvOWM2d85HtTs9lTkPCwI7hTWLqPBGxQnuW8egzT3YefI0A0ysqDMuCBHoX6XVA==,iv:7TU4MaR+97VA8zRs5mCXb2wHblWjBsXO+omKxT9Cf70=,tag:LtcN3usRksQZZKu8CtOqlw==,type:str]
 wireguard:
-  homelab: ENC[AES256_GCM,data:sV1tBTsbd42XIPL1K7jBY0S6FykQpDuesJJusguehlB3oFxmL1aieko7ZykgIYpAu9sRcCAfjQpwA2A24710e7biXkxkIyba5fNV1oj1EF//dKXEEXqa6VIFUXZKl5iXYYsoRWnhP8wzmdT7vMjyWQD1tfjFpOTiLbva+dxWfqG3vcCw9xv7EVIYvl1CuvJLRytQe1XOIK9eIubtcwBy/txtfzzHcBYqHDuE7wqqRY2srVJFHUaG7YhjcgwuFpmHWLlrzlesl3J4r4USLAnmWzPvLqYW1xdnX3iJrTssKMypPvKWCJOxoALUoUR24iaMPCq2w7rVwA1gJkFQ/RLhMTGSJh+JEBOPlmmtSqGvp/ow47uaZezav2AIbCSCQ4TrXCtknA3hLd6TmbZNStt6ijynh0a/K+kra6JzQpV+wIUC3/WKEZrgw38rWEimZpL+7W+ntc5G24zX2w7VwmwyuoGR4aQu+Z+41dXD7v2LeZvYdSQzDR9NIr1apx742Ks+SJTkD2yu6kR56rnfvsJv2YnETScqX4ZBY6frka4PeCKc0psT+5fTIJGq34wv7fy3yOg=,iv:a6cv/TUfPXpO9hlKPmB3stf6hkynPJ5C03Wfqg7d92I=,tag:vFpLMIeqLcA0gTEmdc7jKA==,type:str]
+  homelab: ENC[AES256_GCM,data:n6OYuRWWuvGk2R6ekpwSvesUR3woxQ4vb9bGmudLN5i7Ufk/wXdEUKJLBw8AObUUC2Kt77ODrxsQjLlFE8SmBQ7/X+ykJCti60+dyviWbFVNrWxFQgSsGWgSzwpR+YccT9Vi3zNcm+p0IsXq/ANFW44X/sr832YnKQaVYXlGmRtvQgmfAFvhjMN1fsw/+LOdsyoHdBQqm4MvCWNPFpL5qamOYr5cx7bMXeHmRL5/HqF4thc3BTElyGrvW5y1G44+M4GY6OiSpmc2uM5dKdRzQojYd/c8XMSAED0rpG1zLqXJKaiBeZsejP3ZNCA4zDtHi0XVNYQgnUe1X0CteDUwfZTzxhMBpxRQChH8VC9YUU0RCZa/4E9CwKuHxm2NnoJf6YZcuA/989/Vj2Rom6BU0aJ0FK/xGLtRWaqu4BBYu5c2JRFpcNFpNdWszV8oliQuLdGnsTtfMwNs65MEW8JjfRCIoX1kVGojmgyDEq0L8suU60PvuGYBmzcz9UNx3gZuBh78kNZTIUbtbSdp0u78r70pgHqRwgzVpGcrsHMl4xHfutvcpG9c5xCv52FItw5mv6Y=,iv:5y/KMLiEmx7dC6ccHDcpXarNy9R79qdHT9Vl3nEMSxQ=,tag:CZhAf5SMlpTaPvhwx8xPyg==,type:str]
 ssh_key: ENC[AES256_GCM,data:q9HU8M0LEv9zZdcbYtfmCWVWOYFR2+1F8LoCzy5fXQwdlJMNhNWtsdLN3Vv6QLAZ2+wh83dq/fCTp95g/WbVTh7AcMu/H0TFSMf1+fEwIlXwDbjSGxrblwA5YQB1ObSaRMJFYqxGWlaM+whD/+NhhAF1vYegASYHbKotBj0gXxoTQem8rkUVg5d7f1O90W+kI/y4uKfZ0ad8NU7Tpi5Vkzmmja7IW5eGyzJ5XK/DBQmeaQYxQNe+h27oBbR5gD43PAsrlRbjXwm24UM6VyI3P+tSj9qhIjvoeYate6p9wVwN31vvEso4U7uiZMO6tZKxvoxYXqkllDf5YfbEcQEyp/8b1fWO7uY7a01QdlWhA19IOQr9N6gURfA8DETAShdNQp6sxccJRvbrhe6WVUcWzK1znxRzaRgJg10prujO1cTqVGGkM7Sxweo0CgwjJ+nV0aB/QBlCzJK7wMkrORZ7rQkfGP52Uy7LyLDRIvDnD84TlzbauuWAOBWrH4oyFI76SDspSbI0ozHmKU6JnLF3,iv:V0Su/r1yd7lh5DaVAVsiWWnLSUkBfex/cFfe67s/ECQ=,tag:JLzsC4+LnevEO3IgaHozjA==,type:str]
 sops:
   age:
-    - recipient: age195m7v6w6lce8knleuc9juqwklj56vjflng64q60eh90yrfpsfyjs222pls
-      enc: |
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
         YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBuMzlsd09Fa3hKdkZjazBt
         NG1IZ1lUMTJ6L2VpNjNwT2xMSTd6ejdxTlFFCm5XS0ZsN0p0S3ZDd0JqcllwM3Np
@@ -13,7 +12,8 @@ sops:
         ckxEWjBFakJLeXluSlVGanY2U0x0VFkKuJsXOPFBXR3uwzsnCD/dbx5PgCWM/r5I
         73HNCxrpv4Z6HIp+tUF45aredvrEMles5Wzmot5aTM5l0urYD9ohsQ==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-02-17T01:21:18Z"
-  mac: ENC[AES256_GCM,data:r1QGRXlwPipAUKpZf9vGXYnvPdxBfIq1uu1MBSHDQiNAcK3aAG8qaJvFdSf5cOagAIgT2nCjlkUJZvBLdxgj/ETyh0nMxK6YysgdQ8YFHEX6suy8rLho1p2a0rN3QEe4iKgtH3YFvcVojlXBij19ivVihv6lKsVSNbhi+L0+KKg=,iv:FopbryjgW9awZh9KhsGalEsr5UdmAtHwTr3AE7x3A1c=,tag:HjT661pc3NLMJ0zaYqv/bw==,type:str]
+      recipient: age195m7v6w6lce8knleuc9juqwklj56vjflng64q60eh90yrfpsfyjs222pls
+  lastmodified: "2026-07-23T18:04:27Z"
+  mac: ENC[AES256_GCM,data:XSusH2WtRnM61YtS/azf0cBuZbMPYiqI8Z0IqzTr6YHMT+nZQ/tROD1h9YsP7u0EwgOabtszo2kje85NJOwOzUj47lW+l3WLbRMLf7OYv5f55WTZgOmUg5mifMF1OzHGzAkrVXTgc3N9CvOZMAWYpXZRNBj2SWBVHHBLFrpyHZI=,iv:HpMqVoA0SEggTNlMz2IsrdtS6W/2FkRjsKOBfhrPy88=,tag:WzGBM/3BVk6aNJRgjXwRPw==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.11.0
+  version: 3.13.2


### PR DESCRIPTION
This pull request introduces several improvements and updates across GNU/Linux host and home configurations, with a focus on system package management, display manager enhancements, and secret updates. The most important changes include enabling additional system packages, enhancing the display manager's greeter configuration, updating encrypted secrets, and minor improvements to the Catppuccin theming setup.

**System package and configuration updates:**

* Added `android-tools` to `environment.systemPackages` in `hosts/common/gnu-linux/default.nix` to make Android tools available system-wide, and removed redundant inclusion from `hosts/monolith/games.nix`. [[1]](diffhunk://#diff-c4d73cf76376be1edfbff8e1e1a7a9d64ce69dcbd9975839d96e3ecc814a8ad9R15-R19) [[2]](diffhunk://#diff-3b299634d4990f6ec7e252d2a81522cfd935e4767f634f17537311284493d4b2L30-L31)
* Enabled `wireshark` and commented out `freecad` in `home/common/gnu-linux/programs/default.nix` to adjust available system tools.

**Display manager improvements:**

* Enhanced the `tuigreet` display manager command in `hosts/common/gnu-linux/greeter.nix` to include shutdown and reboot options and to use `start-hyprland` as the session command.

**Theming improvements:**

* Enabled `autoEnable` for Catppuccin theming in multiple home configuration files, ensuring the theme is automatically applied. [[1]](diffhunk://#diff-d68493bfa95c0f422a6ab317eecb228f3f4f2d870046e65135eda446df11f391R17) [[2]](diffhunk://#diff-12d7d5eaadcf154ce5d7a7a34f9985b890f80e22442287051af3c8e99568920eR19) [[3]](diffhunk://#diff-78447981928c0cb4afacc516d92f7afc56c89db2df91a6ed41656e80b6418605R18)

**Secrets and encryption updates:**

* Updated encrypted secrets and metadata in `secrets/bubule/secrets.yaml` and `secrets/monolith/secrets.yaml` to new versions, including changes to Wireguard keys and SOPS metadata. [[1]](diffhunk://#diff-019507bdf10fd8f42af287e5b516a833238a3cf73611167bb9ca58774b780aa1L3-R19) [[2]](diffhunk://#diff-91a18c7a9017e03c80b59b8b4d61e3901035e8f6356608de3bc9ce27ff3db801L3-R19)

**Other improvements:**

* Refactored the argument signature for the main host configuration module to accept `pkgs` (and `lib` where needed) explicitly, improving NixOS module compatibility. [[1]](diffhunk://#diff-c4d73cf76376be1edfbff8e1e1a7a9d64ce69dcbd9975839d96e3ecc814a8ad9L1-R1) [[2]](diffhunk://#diff-5129656d1e9d10e11f0700f1e33e6802c738070b7a3a3a5846f26697e07a73d1L1-R18)

Let me know if you want to discuss any of these changes in more detail!