### PR TITLE
feat: add incus

### DIFF
--- a/hosts/bubule/networking.nix
+++ b/hosts/bubule/networking.nix
@@ -15,5 +15,17 @@
       autostart = false;
       configFile = config.sops.secrets."wireguard/homelab".path;
     };
+
+    bridges = {
+      externalbr0 = {
+        interfaces = ["wlan0"];
+      };
+    };
+
+    # interfaces = {
+    #   externalbr0 = {
+    #     useDHCP = true;
+    #   };
+    # };
   };
 }

--- a/hosts/common/gnu-linux/networking.nix
+++ b/hosts/common/gnu-linux/networking.nix
@@ -19,7 +19,12 @@
     # networking.firewall.allowedTCPPorts = [ ... ];
     # networking.firewall.allowedUDPPorts = [ ... ];
     # Or disable the firewall altogether.
-    firewall.enable = true;
+    firewall= {
+      enable = true;
+      trustedInterfaces = [
+        "incusbr0"
+      ];
+    };
     nftables.enable = true;
 
     # This config does not exists
@@ -33,7 +38,6 @@
     # };
 
     enableIPv6 = true;
-
   };
 
   environment.systemPackages = with pkgs; [

--- a/hosts/common/gnu-linux/networking.nix
+++ b/hosts/common/gnu-linux/networking.nix
@@ -19,7 +19,7 @@
     # networking.firewall.allowedTCPPorts = [ ... ];
     # networking.firewall.allowedUDPPorts = [ ... ];
     # Or disable the firewall altogether.
-    firewall= {
+    firewall = {
       enable = true;
       trustedInterfaces = [
         "incusbr0"

--- a/hosts/common/gnu-linux/virtualisation.nix
+++ b/hosts/common/gnu-linux/virtualisation.nix
@@ -8,7 +8,77 @@
     };
 
     # https://wiki.nixos.org/wiki/Incus
-    incus.enable = true;
+    incus = {
+      enable = true;
+      agent.enable = true;
+      preseed = {
+        networks = [
+          {
+            name = "incusbr0";
+            type = "bridge";
+            description = "Internal/NATted bridge";
+            config = {
+              "ipv4.address" = "auto";
+              "ipv4.nat" = "true";
+              "ipv4.firewall" = "false";
+              "ipv6.address" = "auto";
+              "ipv6.nat" = "true";
+              "ipv6.firewall" = "false";
+            };
+          }
+        ];
+        profiles = [
+          {
+            name = "default";
+            description = "Default Incus Profile";
+
+            devices = {
+              eth0 = {
+                name = "eth0";
+                network = "incusbr0";
+                type = "nic";
+              };
+
+              root = {
+                path = "/";
+                pool = "default";
+                type = "disk";
+              };
+            };
+          }
+
+          # {
+          #   name = "bridged";
+          #   description = "Instances bridged to LAN";
+
+          #   devices = {
+          #     eth0 = {
+          #       name = "eth0";
+          #       nictype = "bridged";
+          #       parent = "externalbr0";
+          #       type = "nic";
+          #     };
+
+          #     root = {
+          #       path = "/";
+          #       pool = "default";
+          #       type = "disk";
+          #     };
+          #   };
+          # }
+        ];
+        storage_pools = [
+          {
+            config = {
+              source = "/var/lib/incus/storage-pools/default";
+            };
+            driver = "dir";
+            name = "default";
+          }
+        ];
+      };
+      ui.enable = true;
+    };
 
     libvirtd = {
       enable = true;

--- a/hosts/monolith/networking.nix
+++ b/hosts/monolith/networking.nix
@@ -17,5 +17,11 @@
       autostart = false;
       configFile = config.sops.secrets."wireguard/homelab".path;
     };
+
+    bridges = {
+      externalbr0 = {
+        interfaces = ["wlan0"];
+      };
+    };
   };
 }


### PR DESCRIPTION
This pull request introduces several improvements to the networking and virtualisation configuration for the NixOS hosts, focusing on enhanced network bridge setup, firewall configuration, and Incus virtualisation integration. The main changes include adding network bridges, refining firewall trust settings, and expanding Incus configuration to support more advanced networking and storage options.

**Networking configuration improvements:**

* Added a new network bridge `externalbr0` (backed by `wlan0`) to both `bubule` and `monolith` hosts, enabling more flexible network setups for containers or VMs. [[1]](diffhunk://#diff-34471282a136ce8e6b33e3a8fe96ca97fb90c3939027cfafde8018b0e1fa81f9R18-R29) [[2]](diffhunk://#diff-ab98162c651202699c1a7a22927d2836e99451d70ae75a752af393fc6d39b8b8R20-R25)
* Updated the firewall configuration to explicitly trust the `incusbr0` bridge, improving compatibility for container networking.

**Incus virtualisation enhancements:**

* Expanded the Incus configuration to use a NixOS preseed, defining a bridged network (`incusbr0`), storage pool, and a default profile with appropriate device mappings. Also enabled the Incus agent and web UI for easier management.

**Other minor changes:**

* Enabled IPv6 support in the common GNU/Linux networking configuration.